### PR TITLE
Create a FAQ Page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -21,4 +21,5 @@
   * [Constructors and pattern matching](constructors.md)
   * [Type polymorphism](polymorphism.md)
 * [Advanced types](advanced_types.md)
+* [FAQ](faq.md)
 

--- a/faq.md
+++ b/faq.md
@@ -1,13 +1,19 @@
 # Frequently Asked Questions
 
 **Q:** Why can't I install Luna Studio on Windows?
+
 **A:** Luna Studio is currently having difficulties installing on certain version of Windows. This is currently being worked on, and a fix should be out before long.
 
+
 **Q:** How do I run programs in Luna?
+
 **A:** In Luna Studio all code is being continuously executed. If you have the code open, it has already begun execution. If you would like to use Luna on the command line, you can find information on how to do so [here](https://github.com/luna/luna).
 
+
 **Q:** How do I use type signatures in Luna?
+
 **A:** We are working on finalizing some of the details of the type system. We want whatever syntax we decide on to be finalized before we release it to you so that your code will be compatible between versions.
 
 **Q:** Can Luna/Luna Studio run in browser?
+
 **A:** Luna Studio could be configured to run in a browser, and much of how the UI was implemented was done specifically with the intent to make the possible to do in the future. However, the core Luna team is not actively working on implementing Luna in browser at the moment.

--- a/faq.md
+++ b/faq.md
@@ -4,7 +4,7 @@
 **A:** Luna Studio is currently having difficulties installing on certain version of Windows. This is currently being worked on, and a fix should be out before long.
 
 **Q:** How do I run programs in Luna?
-**A:** In Luna Studio all code is being continuously executed. If you have the code open, it has already begun execution. If you would like to use Luna on the command line, you can find information on how to do so [here](https://github.com/luna/luna)..
+**A:** In Luna Studio all code is being continuously executed. If you have the code open, it has already begun execution. If you would like to use Luna on the command line, you can find information on how to do so [here](https://github.com/luna/luna).
 
 **Q:** How do I use type signatures in Luna?
 **A:** We are working on finalizing some of the details of the type system. We want whatever syntax we decide on to be finalized before we release it to you so that your code will be compatible between versions.

--- a/faq.md
+++ b/faq.md
@@ -1,0 +1,13 @@
+# Frequently Asked Questions
+
+**Q:** Why can't I install Luna Studio on Windows?
+**A:** Luna Studio is currently having difficulties installing on certain version of Windows. This is currently being worked on, and a fix should be out before long.
+
+**Q:** How do I run programs in Luna?
+**A:** In Luna Studio all code is being continuously executed. If you have the code open, it has already begun execution. If you would like to use Luna on the command line, you can find information on how to do so [here](https://github.com/luna/luna)..
+
+**Q:** How do I use type signatures in Luna?
+**A:** We are working on finalizing some of the details of the type system. We want whatever syntax we decide on to be finalized before we release it to you so that your code will be compatible between versions.
+
+**Q:** Can Luna/Luna Studio run in browser?
+**A:** Luna Studio could be configured to run in a browser, and much of how the UI was implemented was done specifically with the intent to make the possible to do in the future. However, the core Luna team is not actively working on implementing Luna in browser at the moment.


### PR DESCRIPTION
I have initialized a FAQ page with some questions that I have seen asked a lot on the forums/discord. I think having these questions (and more to come) available in the documentation would go a long way towards making Luna approachable to new users.